### PR TITLE
Fix ephemeral broken image link issue

### DIFF
--- a/app/daos/PlaceDAO.scala
+++ b/app/daos/PlaceDAO.scala
@@ -123,8 +123,8 @@ class PlaceDAO @Inject()(val reactiveMongoApi: ReactiveMongoApi, config: Configu
       out.close()
 
       // ...then delete it from the bucket and upload it again under the new filename
-      oldPlace.foreach(s3DAO.deleteImages)
       s3DAO.uploadImages(place, tempFile)
+      oldPlace.foreach(s3DAO.deleteImages)
 
       places.update(Json.obj("id" -> id), place)
     }


### PR DESCRIPTION
If user edited a place without changing the image, the home page would show up before the original image has been re-uploaded to S3 (this is to ensure that the image's key is kept up to date on S3). This has now been fixed.